### PR TITLE
Add GeoIP2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ ARG CONFIG="\
 		--with-file-aio \
 		--with-http_v2_module \
 		--add-module=/usr/src/ngx_brotli \
+		--add-module=/usr/src/ngx_http_geoip2_module \
 	"
 
 FROM alpine:$ALPINE_VERSION
@@ -68,7 +69,9 @@ RUN \
 		gnupg \
 		libxslt-dev \
 		gd-dev \
-		geoip-dev
+		geoip-dev \
+		libmaxminddb-dev  # Added for GeoIP2
+
 RUN \
 	 apk add --no-cache --virtual .brotli-build-deps \
 		tar \
@@ -101,6 +104,9 @@ RUN \
 	&& gpg --batch --verify nginx.tar.gz.asc nginx.tar.gz \
 	&& mkdir -p /usr/src \
 	&& tar -zxC /usr/src -f nginx.tar.gz
+
+RUN cd /usr/src/ && git clone https://github.com/leev/ngx_http_geoip2_module.git
+
 
 RUN \
 	cd /usr/src/nginx-$NGINX_VERSION \

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
 # What is this?
 This project is based on Alpine Linux, the official nginx image and an nginx module that provides static and dynamic brotli compression. [Brotli](https://github.com/google/brotli) and the [nginx brotli module ](https://github.com/google/ngx_brotli) are built by Google.
+This project also adds [GeoIP2](https://docs.nginx.com/nginx/admin-guide/dynamic-modules/geoip2/) module to NGINX to allow capturing information from the client IP address in variables, using the MaxMind GeoIP2 databases, with the GeoIP2 dynamic module.
+
 
 # How to use this image
 As this project is based on the official [nginx image](https://hub.docker.com/_/nginx/) look for instructions there. In addition to the standard configuration directives, you'll be able to use the brotli module specific ones, see [here for official documentation](https://github.com/google/ngx_brotli#configuration-directives)


### PR DESCRIPTION
This PR adds GeoIP2 module to NGINX.
GeoIP2 is a widely used module that allows the server to extract information from the client IP address in variables, using the [MaxMind GeoIP2](https://www.maxmind.com/en/geoip2-databases) databases.